### PR TITLE
[202503] Update Host and single media interfaces IDs per SFF-8024 v4.13 (#596)

### DIFF
--- a/sonic_platform_base/sonic_xcvr/codes/public/sff8024.py
+++ b/sonic_platform_base/sonic_xcvr/codes/public/sff8024.py
@@ -264,8 +264,8 @@ class Sff8024(XcvrCodes):
         78: '200GAUI-2-L C2M (Annex 120G)',
         79: '400GAUI-4-S C2M (Annex 120G)',
         80: '400GAUI-4-L C2M (Annex 120G)',
-        81: '800G S C2M (placeholder)',
-        82: '800G L C2M (placeholder)',
+        81: '800GAUI-8 S C2M (Annex 120G)',
+        82: '800GAUI-8 L C2M (Annex 120G)',
         83: 'OTL4.2'
     }
 
@@ -387,10 +387,10 @@ class Sff8024(XcvrCodes):
         85: '400GBASE-DR4-2 (placeholder)',
         86: '800GBASE-DR8 (placeholder)',
         87: '800GBASE-DR8-2 (placeholder)',
-        151: "100G-DR1-LPO",
-        152: "200G-DR2-LPO",
-        153: "400G-DR4-LPO",
-        154: "800G-DR8-LPO",
+        143: '100G-DR1-LPO',
+        144: '200G-DR2-LPO',
+        145: '400G-DR4-LPO',
+        146: '800G-DR8-LPO',
     }
 
     # Passive and Linear Active Copper Cable and Passive Loopback media interface codes


### PR DESCRIPTION
202503 cherry-pick for https://github.com/sonic-net/sonic-platform-common/pull/596

- Updated codes 81-82: Replaced placeholder text with proper 800GAUI-8 S/L C2M (Annex 120G) specifications
- Fixed LPO code mappings (143-146): Corrected placement from 151-154 range