### PR TITLE
[202405] sfp_base: Add remove_xcvr_api() to support SFP hot swap

### DIFF
--- a/sonic_platform_base/sfp_base.py
+++ b/sonic_platform_base/sfp_base.py
@@ -479,3 +479,9 @@ class SfpBase(device_base.DeviceBase):
         if self._xcvr_api is None:
             self.refresh_xcvr_api()
         return self._xcvr_api
+
+    def remove_xcvr_api(self):
+        """
+        Removes the cached XcvrApi so that the next get_xcvr_api() call will refresh it.
+        """
+        self._xcvr_api = None


### PR DESCRIPTION
#### Description

Adds `SfpBase.remove_xcvr_api()` which clears the cached `XcvrApi` object so that the next `get_xcvr_api()` call rebuilds it via `XcvrApiFactory`.

#### Motivation and Context

Platform-common counterpart of Azure/sonic-platform-daemons.msft#68, which calls `sfp.remove_xcvr_api()` on `SFP_STATUS_REMOVED`. Without this method on the 202405 branch, that call raises `AttributeError` (swallowed by the daemon's `try/except`) and the cached `XcvrApi` (and its underlying `XcvrEeprom` page state) is never refreshed across a transceiver hot swap.

Method body is identical to upstream sonic-net/sonic-platform-common#562 (the read-only cache decorator infrastructure from that PR is not required on 202405 since it does not exist on this branch yet — the only stale state to flush is the `SfpBase._xcvr_api` reference itself).

Related IcM: 807005894

#### How Has This Been Tested?
Ensured that the `show int transceiver info EthernetXX -n asicY` CLI output is inline with expectation in the following scenarios

SONiC OS - 20240532.70

1. Swap 100G and 400G optic (swap optic in ports 32 and 33)
2. Remove optic from port 32 and 33. Reboot the device
2.1 Insert 400G optic in port 32
2.2 Insert 100G optic in port 33
2.3 Remove 100G optic from port 33 and insert 400G optic in port 33 from port 32
2.4 Insert the 100G optic to port 32

The above was validated end-to-end with the merged daemon PR Azure/sonic-platform-daemons.msft#68 on the affected platform via a transceiver hot swap.