### PR TITLE
[chassis_base] Import device_info and fix chassis_base_test imports (fixes 202608 build)

### DIFF
--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -6,6 +6,13 @@
 """
 
 import sys
+try:
+    from sonic_py_common import device_info
+except ImportError:
+    # Unit-test packages may shadow sonic_py_common with a partial mock that
+    # does not provide device_info. This should not occur outside of test
+    # environments.
+    device_info = None
 from . import device_base
 from . import sfp_base
 

--- a/tests/chassis_base_test.py
+++ b/tests/chassis_base_test.py
@@ -1,3 +1,10 @@
+import builtins
+import importlib
+
+import pytest
+from unittest import mock
+
+from sonic_platform_base import chassis_base
 from sonic_platform_base.chassis_base import ChassisBase
 
 class TestChassisBase:
@@ -216,3 +223,27 @@ class TestChassisBase:
         assert chassis.get_pdb(-4) is None
         err_neg = capsys.readouterr().err
         assert "PDB index -4 out of range (0-2)" in err_neg
+
+    def test_device_info_import_failure(self):
+        # Some unit-test packages shadow sonic_py_common with a partial mock
+        # that does not provide device_info. chassis_base must still import
+        # successfully so these tests do not fail, since device_info is only
+        # required by some platform features.
+        real_import = builtins.__import__
+
+        def failing_import(name, *args, **kwargs):
+            if name == "sonic_py_common":
+                raise ImportError("no module named sonic_py_common.device_info")
+            return real_import(name, *args, **kwargs)
+
+        try:
+            with mock.patch.object(builtins, "__import__", failing_import):
+                importlib.reload(chassis_base)
+
+            assert chassis_base.device_info is None
+            chassis_base.ChassisBase()
+        finally:
+            # Restore the module for the remaining tests
+            importlib.reload(chassis_base)
+
+        assert chassis_base.device_info is not None


### PR DESCRIPTION
#### Description

`202608` currently fails to build. PR #128 backported upstream sonic-net/sonic-platform-common#731 (*Provide BMC defaults for system status LED methods in ChassisBase*) into this branch. The cherry-pick applied without conflict, but it landed code that depends on imports `202608` does not have:

| File | Symbol used | Imported? | Result |
|---|---|---|---|
| `sonic_platform_base/chassis_base.py` | `device_info` (3 call sites) | ❌ | `NameError` |
| `tests/chassis_base_test.py` | `mock` | ❌ | module import fails |
| `tests/chassis_base_test.py` | `chassis_base` | ❌ | module import fails |

Because the decorators are evaluated at class-body time, pytest cannot even **collect** `tests/chassis_base_test.py`.

#### Why the import is missing

Upstream gets `device_info` in `chassis_base.py` from sonic-net/sonic-platform-common#700 (*[CPO] Extend ChassisBase to support CPO ports*), which added it in order to call `device_info.get_cpo_data()`. It was later hardened by sonic-net/sonic-platform-common#734 (*Allow device_info import to fail in chassis_base.py*).

Neither was backported to `202608`. PR #128's description states:

> The methods use the module-level `device_info` import that `chassis_base.py` already has

That is true on `master`, but **not** on `202608`. The description was carried over verbatim from the upstream PR by the automated backport, so the missing prerequisite went unnoticed.

#### What this PR does

Backports **only the import** from #734, and adds the two missing test imports.

Deliberately **not** included:
- the CPO hunks of #700/#734 (`cpo_data`/`construct_cpo_devices`) — `202608` has no CPO support, and this is a build fix, not a feature backport
- the CPO-only assertions inside #734's regression test (`mock_get_cpo_data`, `get_num_cpos`)

The `try`/`except ImportError` form is kept rather than a plain import so this hunk matches upstream `master` byte-for-byte, meaning future `202605` → `202608` auto-merges will not conflict here. It also matches the contract asserted by #128's own `test_system_led_no_device_info`, which exercises the `device_info is None` path.

#### Motivation and Context

Unblocks the `202608` `sonic-buildimage` build.

#### How Has This Been Tested?

- `python -m py_compile` passes on both files
- `pyflakes` reports **no undefined names** (previously `mock` and `chassis_base` were undefined)
- `test_device_info_import_failure` covers the `device_info is None` path

Note: `202607`, `202601` and other branches carrying #128-style backports may have the same gap; not checked here.
